### PR TITLE
Yaas go live: Update of OAUTH_TOKEN_URI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
                             <goal>generate-client</goal>
                         </goals>
                         <configuration>
-                            <sourceRamlUri>https://api.yaas.io/hybris/customer/b1/api-console/raml/api/api-specification.raml</sourceRamlUri>
+                            <sourceRamlUri>https://devportal.yaas.io/services/customer/v1/api.raml</sourceRamlUri>
                             <basePackage>com.sap.wishlist.client.customer</basePackage>
                         </configuration>
                     </execution>
@@ -184,7 +184,7 @@
                             <goal>generate-client</goal>
                         </goals>
                         <configuration>
-                            <sourceRamlUri>https://api.yaas.io/hybris/document/b2/api-console/raml/api/document.raml</sourceRamlUri>
+                            <sourceRamlUri>https://devportal.yaas.io/services/document/v1/api.raml</sourceRamlUri>
                             <basePackage>com.sap.wishlist.client.documentrepository</basePackage>
                         </configuration>
                     </execution>
@@ -195,7 +195,7 @@
                             <goal>generate-client</goal>
                         </goals>
                         <configuration>
-                            <sourceRamlUri>https://api.yaas.io/hybris/email/b1/api-console/raml/api/emailservice.raml</sourceRamlUri>
+                            <sourceRamlUri>https://devportal.yaas.io/services/email/v1/api.raml</sourceRamlUri>
                             <basePackage>com.sap.wishlist.client.email</basePackage>
                         </configuration>
                     </execution>
@@ -206,7 +206,7 @@
                             <goal>generate-client</goal>
                         </goals>
                         <configuration>
-                            <sourceRamlUri>https://api.yaas.io/hybris/media/b2/api-console/raml/api/media.raml</sourceRamlUri>
+                            <sourceRamlUri>https://devportal.yaas.io/services/media/v1/api.raml</sourceRamlUri>
                             <basePackage>com.sap.wishlist.client.mediaRepository</basePackage>
                         </configuration>
                     </execution>

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -22,7 +22,7 @@
 ######################
 # OAuth2 client settings
 ######################
-OAUTH2_TOKEN_URI=https://api.yaas.io/hybris/oauth2/b1/token
+OAUTH2_TOKEN_URI=https://api.yaas.io/hybris/oauth2/v1/token
 OAUTH2_SCOPES=hybris.document_view hybris.document_manage hybris.email_send hybris.email_manage hybris.media_manage hybris.customer_read
 
 YAAS_CLIENT_IS_APPLICATION=false


### PR DESCRIPTION
Updated the oauth token uri to https://api.yaas.io/hybris/oauth2/v1/token (was beta).
