### PR TITLE
replaced version of resourceType element

### DIFF
--- a/src/main/resources/api/java-jersey-wishlist.raml
+++ b/src/main/resources/api/java-jersey-wishlist.raml
@@ -29,7 +29,7 @@ traits:
   - !include https://api.yaas.io/patterns/v1/trait-countable.yaml
 
 resourceTypes: 
-  - !include https://api.yaas.io/patterns/v1/resource-type-element.yaml
+  - !include https://api.yaas.io/patterns/v2/resource-type-element.yaml
   - !include https://api.yaas.io/patterns/v1/resource-type-collection.yaml
 
 


### PR DESCRIPTION
The resource type element at uri: https://api.yaas.io/patterns/v1/resource-type-element.yaml is currently deprecated, therefore replaced with new version
