### PR TITLE
Align result to RAML-Definition: return RessourceLocation-Object

### DIFF
--- a/src/main/java/com/sap/wishlist/api/generated/DefaultWishlistsResource.java
+++ b/src/main/java/com/sap/wishlist/api/generated/DefaultWishlistsResource.java
@@ -103,7 +103,12 @@ public class DefaultWishlistsResource implements WishlistsResource {
 		final String id = wishlistMediaService.createWishlistMedia(yaasAware,
 				wishlistId, fileInputStream);
 
-		return Response.created(uriInfo.getRequestUriBuilder().path(id).build()).build();
+		final URI createdLocation = uriInfo.getRequestUriBuilder().path(id).build();
+		final ResourceLocation rc = new ResourceLocation();
+		rc.setId(id);
+		rc.setLink(createdLocation);
+
+		return Response.created(createdLocation).entity(rc).build();
 	}
 
 	/* GET //{wishlistId}/media */

--- a/src/test/java/com/sap/wishlist/api/generated/DefaultWishlistsResourceTest.java
+++ b/src/test/java/com/sap/wishlist/api/generated/DefaultWishlistsResourceTest.java
@@ -210,6 +210,8 @@ public final class DefaultWishlistsResourceTest extends AbstractResourceTest {
                     response.getHeaderString("location").lastIndexOf("/") + 1);
             instanceListMedia.add(mediaId);
             assertNotNull(mediaId);
+
+            assertNotNull("Object RessourceLocation is missing", response.getEntity());
         }
     }
 


### PR DESCRIPTION
In RAML-Definition the POST is defined to Return RessourceLocation.